### PR TITLE
Upped android-maven-plugin version

### DIFF
--- a/sense-android-library/pom.xml
+++ b/sense-android-library/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                 <artifactId>android-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.6.1</version>
                 <configuration>
                     <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
                     <assetsDirectory>${project.basedir}/assets</assetsDirectory>


### PR DESCRIPTION
Upped the `android-maven-plugin` from 3.1.1 to 3.6.1. The older version does not play well with the later Android SDKs (level 17+).
