### PR TITLE
Fix format of burst sensors.

### DIFF
--- a/sense-android-library/src/nl/sense_os/service/motion/MotionBurstSensor.java
+++ b/sense-android-library/src/nl/sense_os/service/motion/MotionBurstSensor.java
@@ -99,7 +99,7 @@ public class MotionBurstSensor extends BaseDataProducer implements DataConsumer 
 		String value = "{\"interval\":"
 				+ Math.round((double) LOCAL_BUFFER_TIME / (double) dataBuffer.size())
 				+ ",\"header\":\"" + MotionSensorUtils.getSensorHeader(sensor).toString()
-				+ "\",\"values\":\"" + dataBufferString + "\"}";
+				+ "\",\"values\":" + dataBufferString + "}";
 
 		try {
 			this.notifySubscribers();


### PR DESCRIPTION
Was a json string containing a vector, now it's a json vector.
