### PR TITLE
Added broadcast when the sense service has started

### DIFF
--- a/sense-android-library/res/values/strings.xml
+++ b/sense-android-library/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string name="action_sense_send_data" translatable="false">nl.sense_os.platform.MsgHandler.SEND_DATA</string>
     <string name="action_sense_alive_check_alarm" translatable="false">nl.sense_os.platform.AliveCheck</string>
     <string name="action_sense_gcm_intent_service" translatable="false">nl.sense_os.service.push.GCMReceiver</string>
-
+    <string name="action_sense_service_broadcast" translatable="false">nl.sense_os.service.Broadcast</string>
+    
     <!-- actions for the app widget -->
     <string name="action_widget_update" translatable="false">nl.sense_os.platform.AppWidgetUpdate</string>
 

--- a/sense-android-library/src/nl/sense_os/service/SenseService.java
+++ b/sense-android-library/src/nl/sense_os/service/SenseService.java
@@ -94,11 +94,12 @@ public class SenseService extends Service {
      * Intent action to force a re-login attempt when the service is started.
      */
     public static final String EXTRA_RELOGIN = "relogin";
-
+    
     /**
-     * Intent action for broadcasts that the service state has changed.
+     * Intent action to notify that the service is started, 
+     * boolean extra for of the status changed broadcast  R.string.action_sense_service_broadcast.
      */
-    public final static String ACTION_SERVICE_BROADCAST = "nl.sense_os.service.Broadcast";
+    public static final String EXTRA_SERVICE_STARTED = "service_started";
 
     private IBinder binder = new SenseBinder();
 
@@ -290,8 +291,6 @@ public class SenseService extends Service {
         Log.v(TAG, "Sense Platform service is being created");
         state = ServiceStateHelper.getInstance(this);
         mSubscrMgr = SubscriptionManager.getInstance();
-        Intent LaunchIntent = getPackageManager().getLaunchIntentForPackage(getApplicationContext().getPackageName());
-        startActivity(LaunchIntent);
     }
 
     /**
@@ -405,6 +404,10 @@ public class SenseService extends Service {
                         startForeground(ServiceStateHelper.NOTIF_ID, n);
                         state.setForeground(true);
                         AliveChecker.scheduleChecks(SenseService.this);
+                        Log.i(TAG, "Sending service started broadcast");
+                        Intent startService = new Intent(getString(R.string.action_sense_service_broadcast));
+                        startService.putExtra(EXTRA_SERVICE_STARTED, "1");
+                        sendBroadcast(startService);
                     }
 
                     // re-login if necessary
@@ -563,7 +566,7 @@ public class SenseService extends Service {
         }
 
         // send broadcast that something has changed in the status
-        sendBroadcast(new Intent(ACTION_SERVICE_BROADCAST));
+        sendBroadcast(new Intent(getString(R.string.action_sense_service_broadcast)));
     }
 
     /**
@@ -582,7 +585,7 @@ public class SenseService extends Service {
         state.setStarted(false);
 
         // send broadcast that something has changed in the status
-        sendBroadcast(new Intent(ACTION_SERVICE_BROADCAST));
+        sendBroadcast(new Intent(getString(R.string.action_sense_service_broadcast)));
     }
 
     synchronized void toggleAmbience(boolean active) {


### PR DESCRIPTION
Added broadcast notification for when the Sense service is started.
Applications can implement a broadcast receiver to do the necessary setup when the sense service is started (e.g. add subscribers, cortex sensors)

Removed the starting of the main application when the service is created. Can given undesired behaviour when the sense service is disabled but created onboot.
@pimnijdam could you qa and merge? Will implement the broadcast receiver for smelly feet and Goalie, ifif this is not done already.
