### PR TITLE
fix bug when agc or ns is not implemented

### DIFF
--- a/sense-android-library/src/nl/sense_os/service/ambience/NoiseSensor.java
+++ b/sense-android-library/src/nl/sense_os/service/ambience/NoiseSensor.java
@@ -223,18 +223,22 @@ public class NoiseSensor extends BaseSensor implements PeriodicPollingSensor {
                         if(AutomaticGainControl.isAvailable()){
                           Log.d(TAG, "AGC is available");
                           AutomaticGainControl agc = AutomaticGainControl.create(audioSessionId);
-                          if(agc.getEnabled()){
-                            Log.d(TAG, "AGC is enabled. Trying to disable.");
-                            agc.setEnabled(false);
+                          if(agc != null){
+                            if(agc.getEnabled()){
+                              Log.d(TAG, "AGC is enabled. Trying to disable.");
+                              agc.setEnabled(false);
+                            }
                           }
                         }
 
                         if(NoiseSuppressor.isAvailable()){
                           Log.d(TAG, "NS is available");
                           NoiseSuppressor ns = NoiseSuppressor.create(audioSessionId);
-                          if(ns.getEnabled()){
-                            Log.d(TAG, "NS is enabled. Trying to disable");
-                            ns.setEnabled(false);
+                          if(ns != null){
+                            if(ns.getEnabled()){
+                              Log.d(TAG, "NS is enabled. Trying to disable");
+                              ns.setEnabled(false);
+                            }
                           }
                         }
 


### PR DESCRIPTION
fixing bug in some devices where create function still return null although getAvailable return true