### PR TITLE
- add getLocalData() with onlyFromDevice parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ local.properties
 # ignore changes to the AppInfoVersion
 sense-android-library/src/nl/sense_os/service/phonestate/AppInfoVersion.java
 docs
+.DS_Store
+sense-android-library/.DS_Store
+sense-android-library/src/.DS_Store
+sense-android-library/src/nl/.DS_Store
+sense-android-library/src/nl/sense_os/.DS_Store

--- a/sense-android-library/src/nl/sense_os/platform/SensePlatform.java
+++ b/sense-android-library/src/nl/sense_os/platform/SensePlatform.java
@@ -482,6 +482,42 @@ public class SensePlatform {
      * @throws JSONException
      *             If the response from CommonSense could not be parsed
      */
+    public JSONArray getLocalData(String sensorName, int limit, boolean onlyFromDevice, long startDate, long endDate) throws IllegalStateException,
+            JSONException {
+        checkSenseService();
+
+        JSONArray result = new JSONArray();
+
+        // select remote path in local storage
+        String localStorage = mContext.getString(R.string.local_storage_authority);
+        Uri uri = Uri.parse("content://" + localStorage + DataPoint.CONTENT_URI_PATH);
+
+        // get the data
+        result = getValues(sensorName, onlyFromDevice, limit, uri, startDate, endDate);
+
+        return result;
+    }
+
+    /**
+     * Retrieve a number of values of a sensor from the local storage.
+     * 
+     * @param sensorName
+     *            The name of the sensor to get data from
+     * @param onlyFromDevice
+     *            Whether or not to only look through sensors that are part of this device. Searches
+     *            all sensors, including those of this device, if set to NO
+     * @param startDate 
+     *            The epoch start date in milliseconds of the period to get the sensor data from
+     * @param endDate 
+     *            The epoch end date in milliseconds of the period to get the sensor data from
+     * @param limit
+     *            Maximum amount of data points.
+     * @return JSONArray of data points
+     * @throws IllegalStateException
+     *             If the Sense service is not bound yet
+     * @throws JSONException
+     *             If the response from CommonSense could not be parsed
+     */
     public JSONArray getLocalData(String sensorName, int limit, long startDate, long endDate) throws IllegalStateException,
             JSONException {
         checkSenseService();


### PR DESCRIPTION
Add another getLocalData() method with additional onlyFromDevice parameter.
We use this on brightr to get mental resilience sensor data that saved to sensor from the 7 initial questions.