### PR TITLE
Fixed crash in fused location provider in stopSensing

### DIFF
--- a/sense-android-library/src/nl/sense_os/service/location/FusedLocationSensor.java
+++ b/sense-android-library/src/nl/sense_os/service/location/FusedLocationSensor.java
@@ -280,9 +280,10 @@ public class FusedLocationSensor extends BaseSensor implements PeriodicPollingSe
 
     @Override
     public void stopSensing() {
-        LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, this);
-        if(googleApiClient.isConnected())
+        if(googleApiClient.isConnected()) {
+            LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, this);
             googleApiClient.disconnect();
+        }
 
         active = false;
         stopAlarms();


### PR DESCRIPTION
Card [N.11]

Fixed:
- crash of the fused location provider when it is stopped